### PR TITLE
Added trimming of directive and policy string

### DIFF
--- a/content_security_policy/parse.py
+++ b/content_security_policy/parse.py
@@ -64,12 +64,12 @@ def value_item_from_string(
 
 
 def directive_from_string(directive_string: str) -> Directive:
-    separators = VALUE_ITEM_SEPARATOR.findall(directive_string)
-    tokens = VALUE_ITEM_SEPARATOR.split(directive_string)
+    trimmed_directive_string: str = directive_string.strip()
+    separators = VALUE_ITEM_SEPARATOR.findall(trimmed_directive_string)
+    tokens = VALUE_ITEM_SEPARATOR.split(trimmed_directive_string)
     if len(separators) != (len(tokens) - 1):
         raise ParsingError(
             "Mismatch in amount of tokens and separators. "
-            "Perhaps your directive is not trimmed?"
         )
     if len(tokens) == 0:
         raise ParsingError("No directive name found in directive string.")
@@ -88,12 +88,12 @@ def directive_from_string(directive_string: str) -> Directive:
 
 
 def policy_from_string(policy_string: str) -> Policy:
-    separators = DIRECTIVE_SEPARATOR.findall(policy_string)
-    directives = DIRECTIVE_SEPARATOR.split(policy_string)
+    trimmed_policy_string: strc = policy_string.strip()
+    separators = DIRECTIVE_SEPARATOR.findall(trimmed_policy_string)
+    directives = DIRECTIVE_SEPARATOR.split(trimmed_policy_string)
     if len(separators) != (len(directives) - 1):
         raise ParsingError(
             "Mismatch in amount of tokens and separators. "
-            "Perhaps your policy is not trimmed?"
         )
 
     # Trailing ';' ...


### PR DESCRIPTION
When used to parse an existing policy, I got an UnrecognizedValueItem for a directive that ended with a space, where the real values were parsed correctly, but there was one extra value created, probably the empty string after the last space. Even though this might be a non-conforming policy, I feel this is a bit too strict, or less forgiving, so I've added trimming of both the policy and the directives, so that any space before a semi-colon, or the end of the policy, are removed. Since the error message mentions lack of trimming (and doesn't work), I removed that part of the error message. 
Note: the error was not triggered since the extra space did create an extra token, so the count logic still holds: there is one more token than separator.
(Note: the problematic space was at the end of the policy, but that was not a problem since spaces are only used for value separators).