### PR TITLE
Fix 3 regular expression errors and warnings

### DIFF
--- a/content_security_policy/patterns.py
+++ b/content_security_policy/patterns.py
@@ -48,18 +48,18 @@ ALPHA = cast(re.Pattern, r"[A-Za-z]")
 DIGIT = cast(re.Pattern, r"[0-9]")
 
 # https://w3c.github.io/webappsec-csp/#grammardef-base64-value
-BASE64_VALUE = cast(re.Pattern, rf"({ALPHA}|{DIGIT}|[+\/\-_]){{2, 0}}={{0, 2}}")
+BASE64_VALUE = cast(re.Pattern, f"({ALPHA}|{DIGIT}|" r"[+/\-_]){2,}={0,2}")
 NONCE_SOURCE = cast(re.Pattern, f"'nonce-{BASE64_VALUE}'")
 HASH_SOURCE = cast(
     re.Pattern, f"'({'|'.join(alg for alg in HASH_ALGORITHMS)})-{BASE64_VALUE}'"
 )
 
 # https://datatracker.ietf.org/doc/html/rfc9110#section-5.6.2
-TOKEN_CHAR = f"[!#$%&'*+\-.^_`|~]|{ALPHA}|{DIGIT}"
+TOKEN_CHAR = r"[!#$%&'*+\-.^_`|~]|" f"{ALPHA}|{DIGIT}"
 TOKEN = cast(re.Pattern, f"({TOKEN_CHAR})+")
 
 # https://datatracker.ietf.org/doc/html/rfc3986#appendix-A
-UNRESERVED = f"({ALPHA}|{DIGIT}|[\-._~])"
+UNRESERVED = f"({ALPHA}|{DIGIT}|" r"[\-._~])"
 HEXDIG = "[0-9a-fA-F]"
 PCT_ENCODED = f"%{HEXDIG}{HEXDIG}"
 # Deviating from rfc3986 here, since CSP explicitly excludes ";" and "," from ALL

--- a/content_security_policy/test/test_values.py
+++ b/content_security_policy/test/test_values.py
@@ -2,9 +2,9 @@ from itertools import chain
 from unittest import TestCase
 
 from content_security_policy.constants import KEYWORD_SOURCES, NONE
-from content_security_policy.parse import _PARSING_RULES
+from content_security_policy.parse import _PARSING_RULES, value_item_from_string, SourceListDirective
 from content_security_policy.utils import kebab_to_snake
-from content_security_policy.values import KeywordSource, NoneSrc
+from content_security_policy.values import KeywordSource, NoneSrc, HashSrc, UnrecognizedValueItem
 
 
 class ValueCompleteness(TestCase):
@@ -39,3 +39,20 @@ class NoneSourceStr(TestCase):
         as_str = "'NOnE'"
         instance = NoneSrc(_value=as_str)
         self.assertEqual(as_str, str(instance))
+
+        
+class HashSrcValue(TestCase):
+    def test_valid_value(self):
+        valid_base64_hash = "'sha256-h20CPZ0QyXlBuAw7A+KluUYx/3pK+c7lYEpqLTlxjYQ='"
+        valid_instance = value_item_from_string(valid_base64_hash, SourceListDirective)
+        self.assertIsInstance(valid_instance, HashSrc)
+
+    def test_invalid_algo(self):
+        valid_base64_hash = "'sha1-h20CPZ0QyXlBuAw7A+KluUYx/3pK+c7lYEpqLTlxjYQ='"
+        invalid_instance = value_item_from_string(valid_base64_hash, SourceListDirective)
+        self.assertIsInstance(invalid_instance, UnrecognizedValueItem)
+
+    def test_invalid_hash(self):
+        valid_base64_hash = "'sha256-******invalid characters in hash value*****='"
+        invalid_instance = value_item_from_string(valid_base64_hash, SourceListDirective)
+        self.assertIsInstance(invalid_instance, UnrecognizedValueItem)

--- a/content_security_policy/test/test_values.py
+++ b/content_security_policy/test/test_values.py
@@ -48,11 +48,11 @@ class HashSrcValue(TestCase):
         self.assertIsInstance(valid_instance, HashSrc)
 
     def test_invalid_algo(self):
-        valid_base64_hash = "'sha1-h20CPZ0QyXlBuAw7A+KluUYx/3pK+c7lYEpqLTlxjYQ='"
-        invalid_instance = value_item_from_string(valid_base64_hash, SourceListDirective)
+        invalid_base64_algo = "'sha1-h20CPZ0QyXlBuAw7A+KluUYx/3pK+c7lYEpqLTlxjYQ='"
+        invalid_instance = value_item_from_string(invalid_base64_algo, SourceListDirective)
         self.assertIsInstance(invalid_instance, UnrecognizedValueItem)
 
     def test_invalid_hash(self):
-        valid_base64_hash = "'sha256-******invalid characters in hash value*****='"
-        invalid_instance = value_item_from_string(valid_base64_hash, SourceListDirective)
+        invalid_base64_hash = "'sha256-******invalid characters in hash value*****='"
+        invalid_instance = value_item_from_string(invalid_base64_hash, SourceListDirective)
         self.assertIsInstance(invalid_instance, UnrecognizedValueItem)


### PR DESCRIPTION
BASE64_VALUE have a range going from 2 to 0, making the interpreter complain, and the regexp failing to match. The 'rf' formatting is also hard to get right, so I simplified by splitting the part that needs variable substitution ('f' prefix) from the raw regexp part ('r' prefix), reducing the amount of curly braces used. Finally removed some white-space that I had trouble with getting matching to work. 

TOKEN_CHAR and UNRESERVED got "SyntaxWarning: invalid escape sequence '\-'" from interpreter, so I split out a raw part from the 'f' prefixed string such that 'f' meta-characters would not interfere. 

I see now that the UNRESERVED instance is due to a previous pull request of mine. Sorry about that!